### PR TITLE
Updated OkHttp3Stack for latest Volley 1.1.0 with Migrating from Apache HTTP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ ext {
     targetSdkVersion = 27
     compileSdkVersion = 27
     gsonVersion = "2.8.2"
-    volleyVersion = "1.0.0"
+    volleyVersion = "1.1.0"
     okHttpVersion = "3.9.1"
     supportLibraryVersion = "27.0.2"
     circleImageViewVersion = "2.2.0"


### PR DESCRIPTION
updated to Volley 1.1.0 and OkHttp3Stack to Migrating-from-Apache-HTTP guide. https://github.com/google/volley/wiki/Migrating-from-Apache-HTTP  
(Apache HTTP Client Removal from Android 6.0 Changes) 
(Optional interceptors support also commented in OkHttp3Stack)